### PR TITLE
Add rigging selection: download and apply character models to dances

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,6 +236,45 @@
             border: none;
         }
 
+        /* ── Bones toggle ───────────────────────────────────── */
+
+        .bones-toggle {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            pointer-events: auto;
+            cursor: pointer;
+            font-size: 12px;
+            color: rgba(255, 255, 255, 0.7);
+            white-space: nowrap;
+            user-select: none;
+        }
+
+        .bones-toggle input[type="checkbox"] {
+            accent-color: #00d9ff;
+            width: 14px;
+            height: 14px;
+            cursor: pointer;
+        }
+
+        /* ── Loading overlay ────────────────────────────────── */
+
+        #loadingOverlay {
+            display: none;
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: rgba(0, 0, 0, 0.7);
+            backdrop-filter: blur(8px);
+            border: 1px solid rgba(0, 217, 255, 0.3);
+            border-radius: 12px;
+            padding: 20px 32px;
+            color: #00d9ff;
+            font-size: 14px;
+            z-index: 2000;
+        }
+
         /* ── Canvas ──────────────────────────────────────────── */
 
         canvas {
@@ -247,6 +286,7 @@
     <!-- Hidden file inputs -->
     <input type="file" id="audioFileInput" class="hidden-input" accept="audio/*">
     <input type="file" id="fbxFileInput" class="hidden-input" accept=".fbx">
+    <input type="file" id="glbFileInput" class="hidden-input" accept=".glb,.gltf,.fbx">
 
     <!-- Top control bar -->
     <div id="uiBar">
@@ -284,8 +324,24 @@
             <option value="./TEST_DATA/NPC_DancingParty_mixamo.fbx">NPC Dancing Party</option>
         </select>
 
+        <div class="separator"></div>
+
+        <select id="riggingSelect" class="bar-select">
+            <option value="skeleton">Skeleton Only</option>
+            <option value="default">Default Character</option>
+            <option value="xbot">X-Bot (Mixamo)</option>
+            <option value="custom">Load GLB...</option>
+        </select>
+
+        <div class="separator"></div>
+
         <button id="loadFbxButton" class="bar-btn">Load FBX</button>
         <button id="loadAudioButton" class="bar-btn">Load Audio</button>
+
+        <label class="bones-toggle">
+            <input type="checkbox" id="skeletonToggle" checked>
+            <span>Bones</span>
+        </label>
 
         <span id="trackName"></span>
     </div>
@@ -295,6 +351,9 @@
         <span id="timeDisplay">0:00 / 0:00</span>
         <input type="range" id="scrubber" min="0" max="1" step="0.001" value="0">
     </div>
+
+    <!-- Loading overlay -->
+    <div id="loadingOverlay">Loading rigging...</div>
 
     <script type="module" src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -1,12 +1,22 @@
-// AutoChoreo — Main Module (Phase 1)
+// AutoChoreo — Main Module (Phase 1 + Rigging Selection)
 
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { FBXLoader } from 'three/addons/loaders/FBXLoader.js';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
 import { TransportController } from './sync.js';
 
 // ── Default FBX to load on startup ──────────────────────────────────
 const DEFAULT_FBX = './TEST_DATA/DancingMedium_mixamo.fbx';
+
+// ── Rigging presets (downloadable from web) ─────────────────────────
+const RIGGING_PRESETS = {
+    xbot: {
+        name: 'X-Bot',
+        url: 'https://threejs.org/examples/models/gltf/Xbot.glb',
+    },
+};
 
 // ── Transport controller (single source of truth) ───────────────────
 const transport = new TransportController();
@@ -18,13 +28,17 @@ const speedValue       = document.getElementById('speedValue');
 const distanceSlider   = document.getElementById('distanceSlider');
 const distanceValue    = document.getElementById('distanceValue');
 const fbxPresetSelect  = document.getElementById('fbxPresetSelect');
+const riggingSelect    = document.getElementById('riggingSelect');
+const skeletonToggle   = document.getElementById('skeletonToggle');
 const loadFbxButton    = document.getElementById('loadFbxButton');
 const loadAudioButton  = document.getElementById('loadAudioButton');
 const audioFileInput   = document.getElementById('audioFileInput');
 const fbxFileInput     = document.getElementById('fbxFileInput');
+const glbFileInput     = document.getElementById('glbFileInput');
 const trackName        = document.getElementById('trackName');
 const scrubber         = document.getElementById('scrubber');
 const timeDisplay      = document.getElementById('timeDisplay');
+const loadingOverlay   = document.getElementById('loadingOverlay');
 
 // ── Three.js scene setup ────────────────────────────────────────────
 const scene    = new THREE.Scene();
@@ -44,78 +58,260 @@ controls.enableDamping = true;
 controls.dampingFactor = 0.05;
 controls.target.set(0, 90, 0);
 
-// Lights
-scene.add(new THREE.AmbientLight(0x404040, 0.6));
-const dirLight = new THREE.DirectionalLight(0xffffff, 1.1);
+// Lights — enhanced for character visibility
+scene.add(new THREE.AmbientLight(0x404040, 0.8));
+const dirLight = new THREE.DirectionalLight(0xffffff, 1.2);
 dirLight.position.set(200, 400, 300);
 dirLight.castShadow = true;
 scene.add(dirLight);
+// Fill light from below-left to reduce dark shadows on characters
+const fillLight = new THREE.DirectionalLight(0x8888ff, 0.4);
+fillLight.position.set(-200, 50, -100);
+scene.add(fillLight);
 
 // Ground grid (sized for cm-scale Mixamo models)
 const grid = new THREE.GridHelper(1000, 20, 0x222222, 0x111111);
 scene.add(grid);
 
-// ── Model state ─────────────────────────────────────────────────────
-let model = null;
+// ── Model & rigging state ───────────────────────────────────────────
+let model = null;            // Currently displayed model in scene
 let skeletonHelper = null;
 let modelCenter = new THREE.Vector3(0, 0, 0);
 let currentDistance = 5;
-const fbxLoader = new FBXLoader();
 
-// ── Load an FBX from URL ────────────────────────────────────────────
-function loadFbxFromUrl(url) {
-    // Tear down previous model
-    teardownModel();
+let danceModel = null;       // FBX model from loaded dance (contains bones, maybe mesh)
+let currentClip = null;      // AnimationClip extracted from current dance
+let riggingMode = 'skeleton'; // 'skeleton' | 'default' | preset key | 'custom'
+let showSkeleton = true;     // Skeleton overlay visibility
+
+const riggingCache = new Map(); // url → THREE.Group (cached downloaded riggings)
+const fbxLoader = new FBXLoader();
+const gltfLoader = new GLTFLoader();
+
+// ── Loading overlay helpers ─────────────────────────────────────────
+function showLoading(msg) {
+    loadingOverlay.textContent = msg || 'Loading...';
+    loadingOverlay.style.display = 'block';
+}
+function hideLoading() {
+    loadingOverlay.style.display = 'none';
+}
+
+// ── Load a dance FBX from URL ───────────────────────────────────────
+function loadDanceFromUrl(url) {
+    teardownDisplay();
+    showLoading('Loading dance...');
 
     fbxLoader.load(
         url,
-        (fbx) => setupModel(fbx),
+        (fbx) => {
+            hideLoading();
+            onDanceLoaded(fbx);
+        },
         undefined,
-        (err) => console.error('Error loading FBX:', err)
+        (err) => {
+            hideLoading();
+            console.error('Error loading FBX:', err);
+        }
     );
 }
 
-// ── Load an FBX from a File object ──────────────────────────────────
-function loadFbxFromFile(file) {
-    teardownModel();
+// ── Load a dance FBX from a File object ─────────────────────────────
+function loadDanceFromFile(file) {
+    teardownDisplay();
 
     const reader = new FileReader();
     reader.onload = (e) => {
         const loader = new FBXLoader();
         const fbx = loader.parse(e.target.result, '');
-        setupModel(fbx);
+        onDanceLoaded(fbx);
     };
     reader.readAsArrayBuffer(file);
 }
 
-// ── Tear down current model/skeleton/mixer ──────────────────────────
-function teardownModel() {
-    if (skeletonHelper) {
-        scene.remove(skeletonHelper);
-        skeletonHelper = null;
+// ── Handle a newly loaded dance FBX ─────────────────────────────────
+function onDanceLoaded(fbx) {
+    danceModel = fbx;
+
+    // Extract animation clip
+    if (fbx.animations && fbx.animations.length > 0) {
+        currentClip = fbx.animations[0];
+        console.log('Dance loaded:', currentClip.name, `(${currentClip.duration.toFixed(1)}s)`);
+    } else {
+        currentClip = null;
+        console.warn('No animations found in FBX file');
     }
-    if (model) {
-        scene.remove(model);
-        model = null;
-    }
-    // Unset animation on transport (but keep audio)
-    transport.setAnimation(null, null, 0);
+
+    // Display based on current rigging mode
+    applyCurrentRigging();
 }
 
-// ── Set up a loaded FBX object ──────────────────────────────────────
-function setupModel(fbx) {
-    model = fbx;
-    // Mixamo FBX files are in centimeters (~180 units tall). No manual scale.
-    // Bounding box and camera setup adapt to whatever units the file uses.
+// ── Apply the current rigging mode ──────────────────────────────────
+function applyCurrentRigging() {
+    if (riggingMode === 'skeleton' || riggingMode === 'default') {
+        // Use the dance model directly
+        if (danceModel) {
+            displayModel(danceModel, riggingMode === 'skeleton');
+        }
+    } else if (riggingMode === 'custom' && riggingCache.has('__custom__')) {
+        // Use custom-loaded rigging
+        displayRiggingWithAnimation(riggingCache.get('__custom__'));
+    } else if (RIGGING_PRESETS[riggingMode]) {
+        // Use a preset rigging — load if not cached
+        const preset = RIGGING_PRESETS[riggingMode];
+        if (riggingCache.has(preset.url)) {
+            displayRiggingWithAnimation(riggingCache.get(preset.url));
+        } else {
+            loadRiggingFromUrl(preset.url);
+        }
+    } else {
+        // Fallback to dance model
+        if (danceModel) {
+            displayModel(danceModel, true);
+        }
+    }
+}
 
-    skeletonHelper = new THREE.SkeletonHelper(model);
-    skeletonHelper.material.color.set(0x00d9ff);
+// ── Load a rigging model from URL (GLB/GLTF) ───────────────────────
+function loadRiggingFromUrl(url) {
+    // Check cache first
+    if (riggingCache.has(url)) {
+        displayRiggingWithAnimation(riggingCache.get(url));
+        return;
+    }
+
+    teardownDisplay();
+    showLoading('Downloading rigging...');
+
+    gltfLoader.load(
+        url,
+        (gltf) => {
+            hideLoading();
+            const rigModel = gltf.scene;
+            riggingCache.set(url, rigModel);
+            displayRiggingWithAnimation(rigModel);
+        },
+        (progress) => {
+            if (progress.total > 0) {
+                const pct = Math.round((progress.loaded / progress.total) * 100);
+                loadingOverlay.textContent = `Downloading rigging... ${pct}%`;
+            }
+        },
+        (err) => {
+            hideLoading();
+            console.error('Error loading rigging:', err);
+            // Fall back to skeleton mode
+            riggingMode = 'skeleton';
+            riggingSelect.value = 'skeleton';
+            if (danceModel) displayModel(danceModel, true);
+        }
+    );
+}
+
+// ── Load a rigging from a local File (GLB/GLTF/FBX) ────────────────
+function loadRiggingFromFile(file) {
+    teardownDisplay();
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+        const ext = file.name.toLowerCase().split('.').pop();
+        let rigModel;
+
+        if (ext === 'fbx') {
+            const loader = new FBXLoader();
+            rigModel = loader.parse(e.target.result, '');
+        } else {
+            // GLB/GLTF
+            const loader = new GLTFLoader();
+            loader.parse(e.target.result, '', (gltf) => {
+                rigModel = gltf.scene;
+                riggingCache.set('__custom__', rigModel);
+                displayRiggingWithAnimation(rigModel);
+            }, (err) => {
+                console.error('Error parsing rigging file:', err);
+            });
+            return; // async parse
+        }
+
+        riggingCache.set('__custom__', rigModel);
+        displayRiggingWithAnimation(rigModel);
+    };
+    reader.readAsArrayBuffer(file);
+}
+
+// ── Display a rigging model with the current animation applied ──────
+function displayRiggingWithAnimation(sourceModel) {
+    teardownDisplay();
+
+    // Clone so the cached original stays clean
+    const cloned = SkeletonUtils.clone(sourceModel);
+
+    // Scale GLB models to match Mixamo scale (GLB is meters, Mixamo FBX is cm)
+    // Detect by checking bounding box — if model is < 10 units tall, scale up
+    const box = new THREE.Box3().setFromObject(cloned);
+    const height = box.max.y - box.min.y;
+    if (height < 10) {
+        cloned.scale.setScalar(100); // meters → centimeters
+    }
+
+    displayModel(cloned, false);
+
+    // Apply the current dance animation to this rigging
+    if (currentClip) {
+        const mixer = new THREE.AnimationMixer(model);
+        const action = mixer.clipAction(currentClip);
+        action.play();
+
+        transport.setAnimation(mixer, action, currentClip.duration);
+        transport.play();
+    }
+}
+
+// ── Display a model in the scene ────────────────────────────────────
+function displayModel(targetModel, hideAllMeshes) {
+    teardownDisplay();
+
+    model = targetModel;
+
+    // Control mesh visibility
+    model.traverse((child) => {
+        if (child.isMesh || child.isSkinnedMesh) {
+            child.visible = !hideAllMeshes;
+            child.castShadow = true;
+            child.receiveShadow = true;
+            // Ensure materials are double-sided for visibility
+            if (child.material) {
+                const mats = Array.isArray(child.material) ? child.material : [child.material];
+                mats.forEach(mat => { mat.side = THREE.DoubleSide; });
+            }
+        }
+    });
 
     scene.add(model);
+
+    // Skeleton helper
+    skeletonHelper = new THREE.SkeletonHelper(model);
+    skeletonHelper.material.color.set(0x00d9ff);
+    skeletonHelper.visible = showSkeleton;
     scene.add(skeletonHelper);
 
-    // Compute bounding box from model geometry
-    const box = new THREE.Box3().setFromObject(model);
+    // Compute bounding box and frame camera
+    frameCameraOnModel(model);
+
+    // If using the dance model directly (skeleton/default mode), set up animation
+    if (targetModel === danceModel && currentClip) {
+        const mixer = new THREE.AnimationMixer(model);
+        const action = mixer.clipAction(currentClip);
+        action.play();
+
+        transport.setAnimation(mixer, action, currentClip.duration);
+        transport.play();
+    }
+}
+
+// ── Frame camera on a model ─────────────────────────────────────────
+function frameCameraOnModel(targetModel) {
+    const box = new THREE.Box3().setFromObject(targetModel);
     const center = box.getCenter(new THREE.Vector3());
     const size = box.getSize(new THREE.Vector3());
     modelCenter.copy(center);
@@ -124,33 +320,38 @@ function setupModel(fbx) {
     const baseDistance = maxDim * 3;
     currentDistance = baseDistance;
 
-    // Position camera in front of model, centered
     camera.position.set(center.x, center.y, center.z + baseDistance);
     camera.lookAt(center);
     controls.target.copy(center);
     controls.update();
 
-    // Distance slider range
     distanceSlider.min = baseDistance * 0.3;
     distanceSlider.max = baseDistance * 4;
     distanceSlider.value = baseDistance;
     updateDistanceDisplay();
+}
 
-    // Animation
-    if (fbx.animations && fbx.animations.length > 0) {
-        const mixer = new THREE.AnimationMixer(model);
-        const action = mixer.clipAction(fbx.animations[0]);
-        action.play();
-
-        const clipDuration = fbx.animations[0].duration;
-        transport.setAnimation(mixer, action, clipDuration);
-
-        // Auto-play
-        transport.play();
-        console.log('Animation loaded:', fbx.animations[0].name, `(${clipDuration.toFixed(1)}s)`);
-    } else {
-        console.warn('No animations found in FBX file');
+// ── Tear down displayed model ───────────────────────────────────────
+function teardownDisplay() {
+    if (skeletonHelper) {
+        scene.remove(skeletonHelper);
+        skeletonHelper = null;
     }
+    if (model) {
+        scene.remove(model);
+        model = null;
+    }
+    transport.setAnimation(null, null, 0);
+}
+
+// ── Set mesh visibility on a model ──────────────────────────────────
+function setMeshVisibility(targetModel, visible) {
+    if (!targetModel) return;
+    targetModel.traverse((child) => {
+        if (child.isMesh || child.isSkinnedMesh) {
+            child.visible = visible;
+        }
+    });
 }
 
 // ── Camera distance helper ──────────────────────────────────────────
@@ -251,11 +452,11 @@ scrubber.addEventListener('mouseup', endScrub);
 scrubber.addEventListener('touchend', endScrub);
 scrubber.addEventListener('change', endScrub); // fallback
 
-// FBX preset dropdown
+// FBX preset dropdown (dance selection)
 fbxPresetSelect.addEventListener('change', (e) => {
     const url = e.target.value;
     if (url) {
-        loadFbxFromUrl(url);
+        loadDanceFromUrl(url);
     }
 });
 
@@ -263,8 +464,8 @@ fbxPresetSelect.addEventListener('change', (e) => {
 loadFbxButton.addEventListener('click', () => fbxFileInput.click());
 fbxFileInput.addEventListener('change', (e) => {
     const file = e.target.files[0];
-    if (file) loadFbxFromFile(file);
-    fbxFileInput.value = ''; // reset so same file can be reloaded
+    if (file) loadDanceFromFile(file);
+    fbxFileInput.value = '';
 });
 
 // Load Audio button → trigger hidden file input
@@ -275,6 +476,65 @@ audioFileInput.addEventListener('change', async (e) => {
         await transport.loadAudio(file);
     }
     audioFileInput.value = '';
+});
+
+// ── Rigging selection ───────────────────────────────────────────────
+riggingSelect.addEventListener('change', (e) => {
+    const value = e.target.value;
+
+    if (value === 'custom') {
+        // Open file picker for custom GLB
+        glbFileInput.click();
+        return;
+    }
+
+    riggingMode = value;
+
+    if (value === 'skeleton') {
+        // Show skeleton only from dance model
+        if (danceModel) {
+            showSkeleton = true;
+            skeletonToggle.checked = true;
+            displayModel(danceModel, true);
+            if (currentClip) {
+                // Animation is set up in displayModel
+            }
+        }
+    } else if (value === 'default') {
+        // Show mesh from dance model
+        if (danceModel) {
+            displayModel(danceModel, false);
+        }
+    } else if (RIGGING_PRESETS[value]) {
+        // Download and display preset rigging
+        const preset = RIGGING_PRESETS[value];
+        if (riggingCache.has(preset.url)) {
+            displayRiggingWithAnimation(riggingCache.get(preset.url));
+        } else {
+            loadRiggingFromUrl(preset.url);
+        }
+    }
+});
+
+// Custom GLB file input
+glbFileInput.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (file) {
+        riggingMode = 'custom';
+        loadRiggingFromFile(file);
+    } else {
+        // User cancelled — revert dropdown to previous value
+        riggingSelect.value = riggingMode;
+    }
+    glbFileInput.value = '';
+});
+
+// Skeleton toggle
+skeletonToggle.addEventListener('change', (e) => {
+    showSkeleton = e.target.checked;
+    if (skeletonHelper) {
+        skeletonHelper.visible = showSkeleton;
+    }
 });
 
 // ── Resize handler ──────────────────────────────────────────────────
@@ -297,7 +557,7 @@ function animate() {
 animate();
 
 // ── Load default FBX on startup ─────────────────────────────────────
-loadFbxFromUrl(DEFAULT_FBX);
+loadDanceFromUrl(DEFAULT_FBX);
 fbxPresetSelect.value = DEFAULT_FBX;
 
-console.log('AutoChoreo initialized');
+console.log('AutoChoreo initialized (with rigging selection)');


### PR DESCRIPTION
Separates the concept of "dance" (animation data from FBX) from "rigging"
(character model). Users can now select different rigged characters to
perform the loaded dance animations:

- Rigging dropdown with Skeleton Only, Default Character, X-Bot (Mixamo),
  and Load GLB options
- Downloads X-Bot model from threejs.org CDN with progress indicator
- Applies dance animation clips to any Mixamo-compatible character model
- Supports loading custom GLB/GLTF/FBX rigging files from disk
- Caches downloaded riggings to avoid re-downloading
- Auto-scales GLB models (meters) to match Mixamo FBX scale (centimeters)
- Bones toggle checkbox to show/hide skeleton overlay on any rigging
- Enhanced lighting (fill light) for better character mesh visibility
- Loading overlay with download progress feedback

https://claude.ai/code/session_01XZJQxpqHo8gdiJ6RQ9bXmz